### PR TITLE
add `encode_` or `decode_` to test names to clarify and avoid name collisions - Update run_length_encoding_test.rb

### DIFF
--- a/exercises/run-length-encoding/run_length_encoding_test.rb
+++ b/exercises/run-length-encoding/run_length_encoding_test.rb
@@ -5,7 +5,7 @@ require_relative 'run_length_encoding'
 
 # Common test data version: 503a57a
 class RunLengthEncodingTest < Minitest::Test
-  def test_empty_string
+  def test_encode_empty_string
     # skip
     input = ''
     output = ''
@@ -19,70 +19,70 @@ class RunLengthEncodingTest < Minitest::Test
     assert_equal output, RunLengthEncoding.encode(input)
   end
 
-  def test_string_with_no_single_characters
+  def test_encode_string_with_no_single_characters
     skip
     input = 'AABBBCCCC'
     output = '2A3B4C'
     assert_equal output, RunLengthEncoding.encode(input)
   end
 
-  def test_single_characters_mixed_with_repeated_characters
+  def test_encode_single_characters_mixed_with_repeated_characters
     skip
     input = 'WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB'
     output = '12WB12W3B24WB'
     assert_equal output, RunLengthEncoding.encode(input)
   end
 
-  def test_multiple_whitespace_mixed_in_string
+  def test_encode_multiple_whitespace_mixed_in_string
     skip
     input = '  hsqq qww  '
     output = '2 hs2q q2w2 '
     assert_equal output, RunLengthEncoding.encode(input)
   end
 
-  def test_lowercase_characters
+  def test_encode_lowercase_characters
     skip
     input = 'aabbbcccc'
     output = '2a3b4c'
     assert_equal output, RunLengthEncoding.encode(input)
   end
 
-  def test_empty_string
+  def test_decode_empty_string
     skip
     input = ''
     output = ''
     assert_equal output, RunLengthEncoding.decode(input)
   end
 
-  def test_single_characters_only
+  def test_decode_single_characters_only
     skip
     input = 'XYZ'
     output = 'XYZ'
     assert_equal output, RunLengthEncoding.decode(input)
   end
 
-  def test_string_with_no_single_characters
+  def test_decode_string_with_no_single_characters
     skip
     input = '2A3B4C'
     output = 'AABBBCCCC'
     assert_equal output, RunLengthEncoding.decode(input)
   end
 
-  def test_single_characters_with_repeated_characters
+  def test_decode_single_characters_with_repeated_characters
     skip
     input = '12WB12W3B24WB'
     output = 'WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB'
     assert_equal output, RunLengthEncoding.decode(input)
   end
 
-  def test_multiple_whitespace_mixed_in_string
+  def test_decode_multiple_whitespace_mixed_in_string
     skip
     input = '2 hs2q q2w2 '
     output = '  hsqq qww  '
     assert_equal output, RunLengthEncoding.decode(input)
   end
 
-  def test_lower_case_string
+  def test_decode_lower_case_string
     skip
     input = '2a3b4c'
     output = 'aabbbcccc'


### PR DESCRIPTION
## Why?
1) This provides added clarity for which tests are running/failing/passing.
2) This fixes a name collision bug between:
`def test_empty_string` for `encode` on line `10`
and 
`def test_empty_string` for `decode` on line `50`

## What?
I added `encode_` or `decode_` as a prefix for the test names that did not already specify which method they were testing.

## How Has This Been Tested?
I used this version to complete the exercism locally

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or enhancement that would cause existing functionality to change)
- [x] Gardening (code and/or documentation cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My change relies on a pending issue/pull request
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
